### PR TITLE
Define error JSON path

### DIFF
--- a/getmsgserv/LM_work/sendtoLM.py
+++ b/getmsgserv/LM_work/sendtoLM.py
@@ -9,6 +9,9 @@ from dashscope.api_entities.dashscope_response import Role
 import re
 import sqlite3
 
+# File path used to save erroneous JSON output
+output_file_path_error = "./cache/LM_error.json"
+
 def read_config(file_path):
     config = {}
     with open(file_path, 'r') as f:


### PR DESCRIPTION
## Summary
- define `output_file_path_error` near the top of `sendtoLM.py`
- use this path when writing invalid JSON

## Testing
- `python3 -m py_compile getmsgserv/LM_work/sendtoLM.py`

------
https://chatgpt.com/codex/tasks/task_e_68432736a454832390900d00a76d7ff2