### PR TITLE
Fix race in sender table updates

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -187,7 +187,8 @@ CREATE TABLE sender (
     ACgroup TEXT,
     rawmsg TEXT,
     modtime TEXT,
-    processtime TEXT
+    processtime TEXT,
+    UNIQUE(senderid, receiver)
 );
 CREATE TABLE preprocess (
     tag INT,


### PR DESCRIPTION
## Summary
- ensure one `(senderid, receiver)` row by adding UNIQUE constraint
- serialise DB writes with a lock
- use UPSERT when recording private messages

## Testing
- `python3 -m py_compile getmsgserv/serv.py`

------
https://chatgpt.com/codex/tasks/task_e_68469db75e648323bafef9001121622e